### PR TITLE
Bdt Beam Particle Id & Test Beam Particle Creation

### DIFF
--- a/settings/PandoraSettings_Master_ProtoDUNE.xml
+++ b/settings/PandoraSettings_Master_ProtoDUNE.xml
@@ -1,6 +1,6 @@
 <pandora>
     <!-- GLOBAL SETTINGS -->
-    <IsMonitoringEnabled>false</IsMonitoringEnabled>
+    <IsMonitoringEnabled>true</IsMonitoringEnabled>
     <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
     <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
 
@@ -31,12 +31,8 @@
         </CosmicRayTaggingTools>
         <SliceIdTools>
             <tool type = "LArBdtBeamParticleId">
-                <UseTrainingMode>false</UseTrainingMode>
-                <MinimumPurity>0.8</MinimumPurity>
-                <MinimumCompleteness>0.8</MinimumCompleteness>
                 <BdtName>BeamParticleId</BdtName>
                 <BdtFileName>BdtBeamParticleID_NTrees_200_TreeDepth_3.xml</BdtFileName>
-                <MaximumNeutrinos>10000</MaximumNeutrinos>
                 <MinAdaBDTScore>-0.2</MinAdaBDTScore>
             </tool>
         </SliceIdTools>
@@ -58,6 +54,19 @@
 
     <algorithm type = "LArTestBeamParticleCreation">
         <PfoListName>RecreatedPfos</PfoListName>
+    </algorithm>
+
+    <algorithm type = "LArEventValidation">
+        <CaloHitListName>CaloHitList2D</CaloHitListName>
+        <MCParticleListName>Input</MCParticleListName>
+        <PfoListName>RecreatedPfos</PfoListName>
+        <UseTrueNeutrinosOnly>false</UseTrueNeutrinosOnly>
+        <PrintAllToScreen>false</PrintAllToScreen>
+        <PrintMatchingToScreen>true</PrintMatchingToScreen>
+        <WriteToTree>false</WriteToTree>
+        <OutputTree>Validation</OutputTree>
+        <OutputFile>Validation.root</OutputFile>
+        <TestBeamMode>true</TestBeamMode>
     </algorithm>
 
     <algorithm type = "LArVisualMonitoring">

--- a/settings/PandoraSettings_Master_ProtoDUNE.xml
+++ b/settings/PandoraSettings_Master_ProtoDUNE.xml
@@ -30,7 +30,15 @@
             <tool type = "LArCosmicRayTagging"/>
         </CosmicRayTaggingTools>
         <SliceIdTools>
-            <tool type = "LArBeamParticleId"><BeamTPCIntersection>-33.051 461.06 0.</BeamTPCIntersection></tool>
+            <tool type = "LArBdtBeamParticleId">
+                <UseTrainingMode>false</UseTrainingMode>
+                <MinimumPurity>0.8</MinimumPurity>
+                <MinimumCompleteness>0.8</MinimumCompleteness>
+                <BdtName>BeamParticleId</BdtName>
+                <BdtFileName>BdtBeamParticleID_NTrees_200_TreeDepth_3.xml</BdtFileName>
+                <MaximumNeutrinos>10000</MaximumNeutrinos>
+                <MinAdaBDTScore>-0.2</MinAdaBDTScore>
+            </tool>
         </SliceIdTools>
         <InputHitListName>Input</InputHitListName>
         <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
@@ -47,6 +55,11 @@
         <PfoListName>RecreatedPfos</PfoListName>
         <VertexListName>RecreatedVertices</VertexListName>
     </algorithm>
+
+    <algorithm type = "LArTestBeamParticleCreation">
+        <PfoListName>RecreatedPfos</PfoListName>
+    </algorithm>
+
     <algorithm type = "LArVisualMonitoring">
         <ShowCurrentPfos>true</ShowCurrentPfos>
         <ShowDetector>true</ShowDetector>


### PR DESCRIPTION
I have altered the ProtoDUNE Pandora Settings file to use the BDT beam particle id and to run test beam particle creation algorithm.  

I would recommend merging this pull request after the next group meeting so that I can add some performance metrics plots to go alongside this pull request just to double check overtraining is not an issue.  I will create a similar pull request for the LArMachineLearning library containing the trained Bdt xml file and the python script used to generate it. 