### PR TITLE
BDT Name & TestBeamParticleCreation

### DIFF
--- a/settings/PandoraSettings_Master_ProtoDUNE.xml
+++ b/settings/PandoraSettings_Master_ProtoDUNE.xml
@@ -32,7 +32,7 @@
         <SliceIdTools>
             <tool type = "LArBdtBeamParticleId">
                 <BdtName>BeamParticleId</BdtName>
-                <BdtFileName>BdtBeamParticleID_NTrees_200_TreeDepth_3.xml</BdtFileName>
+                <BdtFileName>PandoraBdt_v03_12_00.xml</BdtFileName>
                 <MinAdaBDTScore>-0.2</MinAdaBDTScore>
             </tool>
         </SliceIdTools>
@@ -54,6 +54,7 @@
 
     <algorithm type = "LArTestBeamParticleCreation">
         <PfoListName>RecreatedPfos</PfoListName>
+        <VertexListName>RecreatedVertices</VertexListName>
     </algorithm>
 
     <algorithm type = "LArEventValidation">


### PR DESCRIPTION
Renamed bdt file and adjusted settings for test beam particle creation algorithm.  The test beam particle creation algorithm now positions the vertex at the start (i.e. lowest z) of the 3D clusters.