### PR TITLE
Test Beam Validation.C

### DIFF
--- a/validation/Validation.C
+++ b/validation/Validation.C
@@ -316,7 +316,7 @@ void CountPfoMatches(const SimpleMCEvent &simpleMCEvent, const Parameters &param
             ++countingDetails.m_nTotal;
 
             // ATTN Fail cosmic ray matches to neutrinos (or beam particles) and vice versa
-            if ((simpleMCPrimary.m_bestMatchPfoId >= 0) && (simpleMCTarget.m_isCosmicRay == simpleMCPrimary.m_bestMatchPfoIsRecoNu))
+            if ((simpleMCPrimary.m_bestMatchPfoId >= 0) && (!simpleMCTarget.m_isBeamParticle && (simpleMCTarget.m_isCosmicRay == simpleMCPrimary.m_bestMatchPfoIsRecoNu)))
             {
                 ++countingDetails.m_nMatch0;
                 continue;


### PR DESCRIPTION
Removed line failing test beam events in Validation.C correct event fraction calculations.  This is mainly a temporary fix and we need to add a feature that says whether a matched pfo is a test beam, neutrino or cosmic ray.  This could be done via pdg code, but there's no distinction between shower like test beam particles and shower like cosmic rays.