### PR TITLE
feature/SBNDValidation

### DIFF
--- a/settings/PandoraSettings_Master_SBND.xml
+++ b/settings/PandoraSettings_Master_SBND.xml
@@ -1,0 +1,60 @@
+<pandora>
+    <!-- GLOBAL SETTINGS -->
+    <IsMonitoringEnabled>true</IsMonitoringEnabled>
+    <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
+    <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
+
+    <!-- ALGORITHM SETTINGS -->
+    <algorithm type = "LArEventReading"/>
+    <algorithm type = "LArPreProcessing">
+        <OutputCaloHitListNameU>CaloHitListU</OutputCaloHitListNameU>
+        <OutputCaloHitListNameV>CaloHitListV</OutputCaloHitListNameV>
+        <OutputCaloHitListNameW>CaloHitListW</OutputCaloHitListNameW>
+        <FilteredCaloHitListName>CaloHitList2D</FilteredCaloHitListName>
+        <CurrentCaloHitListReplacement>CaloHitList2D</CurrentCaloHitListReplacement>
+    </algorithm>
+    <algorithm type = "LArVisualMonitoring">
+        <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW</CaloHitListNames>
+        <ShowDetector>true</ShowDetector>
+    </algorithm>
+
+    <algorithm type = "LArMaster">
+        <CRSettingsFile>PandoraSettings_Cosmic_Standard.xml</CRSettingsFile>
+        <NuSettingsFile>PandoraSettings_Neutrino_Standard.xml</NuSettingsFile>
+        <SlicingSettingsFile>PandoraSettings_Slicing_Standard.xml</SlicingSettingsFile>
+        <StitchingTools>
+            <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>true</ThreeDStitchingMode></tool>
+            <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>false</ThreeDStitchingMode></tool>
+        </StitchingTools>
+        <CosmicRayTaggingTools>
+            <tool type = "LArCosmicRayTagging"/>
+        </CosmicRayTaggingTools>
+        <SliceIdTools>
+            <tool type = "LArSimpleNeutrinoId"/>
+        </SliceIdTools>
+        <InputHitListName>Input</InputHitListName>
+        <InputMCParticleListName>Input</InputMCParticleListName>
+        <PassMCParticlesToWorkerInstances>false</PassMCParticlesToWorkerInstances>
+        <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
+        <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
+        <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>
+        <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
+    </algorithm>
+
+    <algorithm type = "LArEventValidation">
+        <CaloHitListName>CaloHitList2D</CaloHitListName>
+        <MCParticleListName>Input</MCParticleListName>
+        <PfoListName>RecreatedPfos</PfoListName>
+        <UseTrueNeutrinosOnly>false</UseTrueNeutrinosOnly>
+        <PrintAllToScreen>false</PrintAllToScreen>
+        <PrintMatchingToScreen>true</PrintMatchingToScreen>
+        <WriteToTree>false</WriteToTree>
+        <OutputTree>Validation</OutputTree>
+        <OutputFile>Validation.root</OutputFile>
+    </algorithm>
+
+    <algorithm type = "LArVisualMonitoring">
+        <ShowCurrentPfos>true</ShowCurrentPfos>
+        <ShowDetector>true</ShowDetector>
+    </algorithm>
+</pandora>

--- a/validation/Validation.h
+++ b/validation/Validation.h
@@ -28,6 +28,7 @@ public:
     int                     m_skipEvents;               ///< The number of events to skip
     int                     m_nEventsToProcess;         ///< The number of events to process
     bool                    m_applyUbooneFiducialCut;   ///< Whether to apply uboone fiducial volume cut to true neutrino vertex position
+    bool                    m_applySBNDFiducialCut;     ///< Whether to apply sbnd fiducial volume cut to true neutrino vertex position
     bool                    m_correctTrackShowerId;     ///< Whether to demand that pfos are correctly flagged as tracks or showers
     float                   m_vertexXCorrection;        ///< The vertex x correction, added to reported mc neutrino endpoint x value, in cm
     bool                    m_histogramOutput;          ///< Whether to produce output histograms
@@ -569,6 +570,16 @@ void CountPfoMatches(const SimpleMCEvent &simpleMCEvent, const Parameters &param
     InteractionTargetResultMap &interactionTargetResultMap);
 
 /**
+ *  @brief  Whether a simple mc event passes the relevant fiducial cut, applied to target vertices
+ *
+ *  @param  simpleMCTarget the simple mc target
+ *  @param  parameters the parameters
+ *
+ *  @return boolean
+ */
+bool PassFiducialCut(const SimpleMCTarget &simpleMCTarget, const Parameters &parameters);
+
+/**
  *  @brief  Whether a simple mc event passes uboone fiducial cut, applied to target vertices
  *
  *  @param  simpleMCTarget the simple mc target
@@ -576,6 +587,15 @@ void CountPfoMatches(const SimpleMCEvent &simpleMCEvent, const Parameters &param
  *  @return boolean
  */
 bool PassUbooneFiducialCut(const SimpleMCTarget &simpleMCTarget);
+
+/**
+ *  @brief  Whether a simple mc event passes sbnd fiducial cut, applied to target vertices
+ *
+ *  @param  simpleMCTarget the simple mc target
+ *
+ *  @return boolean
+ */
+bool PassSBNDFiducialCut(const SimpleMCTarget &simpleMCTarget);
 
 /**
  *  @brief  Work out which of the primary particles (expected for a given interaction types) corresponds to the provided primary id
@@ -647,6 +667,7 @@ Parameters::Parameters() :
     m_skipEvents(0),
     m_nEventsToProcess(std::numeric_limits<int>::max()),
     m_applyUbooneFiducialCut(true),
+    m_applySBNDFiducialCut(false),
     m_correctTrackShowerId(false),
     m_vertexXCorrection(0.495694f),
     m_histogramOutput(false),


### PR DESCRIPTION
I am going to train the vertex SVM for SBND so I want to run the validation before and after to see what effect it has.

Added a master settings file for SBND identical to the standard but without test beam mode for the event validation so that I can add the vertex SVM output in the future. 
Also modified the validation script to check if the event passes an SBND fiducial cut and then make sure it's not asked for more than 1 fiducial cut (i.e. SBND & uBooNE).