### PR TITLE
Altering input hit list name to master algorithm.

### DIFF
--- a/settings/PandoraSettings_Master_DUNEFD.xml
+++ b/settings/PandoraSettings_Master_DUNEFD.xml
@@ -32,7 +32,7 @@
         <SliceIdTools>
             <tool type = "LArSimpleNeutrinoId"/>
         </SliceIdTools>
-        <InputHitListName>Input</InputHitListName>
+        <InputHitListName>CaloHitList2D</InputHitListName>
         <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
         <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
         <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>

--- a/settings/PandoraSettings_Master_ICARUS.xml
+++ b/settings/PandoraSettings_Master_ICARUS.xml
@@ -39,7 +39,7 @@
                 <SelectAllNeutrinos>true</SelectAllNeutrinos>
             </tool>
         </SliceIdTools>
-        <InputHitListName>Input</InputHitListName>
+        <InputHitListName>CaloHitList2D</InputHitListName>
         <InputMCParticleListName>Input</InputMCParticleListName>
         <PassMCParticlesToWorkerInstances>false</PassMCParticlesToWorkerInstances>
         <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>

--- a/settings/PandoraSettings_Master_MicroBooNE.xml
+++ b/settings/PandoraSettings_Master_MicroBooNE.xml
@@ -35,7 +35,7 @@
                 <SvmName>NeutrinoId</SvmName>
             </tool>
         </SliceIdTools>
-        <InputHitListName>Input</InputHitListName>
+        <InputHitListName>CaloHitList2D</InputHitListName>
         <InputMCParticleListName>Input</InputMCParticleListName>
         <PassMCParticlesToWorkerInstances>false</PassMCParticlesToWorkerInstances>
         <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>

--- a/settings/PandoraSettings_Master_ProtoDUNE.xml
+++ b/settings/PandoraSettings_Master_ProtoDUNE.xml
@@ -36,7 +36,7 @@
                 <MinAdaBDTScore>-0.225</MinAdaBDTScore>
             </tool>
         </SliceIdTools>
-        <InputHitListName>Input</InputHitListName>
+        <InputHitListName>CaloHitList2D</InputHitListName>
         <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>
         <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
         <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>

--- a/settings/PandoraSettings_Master_SBND.xml
+++ b/settings/PandoraSettings_Master_SBND.xml
@@ -32,7 +32,7 @@
         <SliceIdTools>
             <tool type = "LArSimpleNeutrinoId"/>
         </SliceIdTools>
-        <InputHitListName>Input</InputHitListName>
+        <InputHitListName>CaloHitList2D</InputHitListName>
         <InputMCParticleListName>Input</InputMCParticleListName>
         <PassMCParticlesToWorkerInstances>false</PassMCParticlesToWorkerInstances>
         <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>

--- a/settings/PandoraSettings_Master_Standard.xml
+++ b/settings/PandoraSettings_Master_Standard.xml
@@ -32,7 +32,7 @@
         <SliceIdTools>
             <tool type = "LArSimpleNeutrinoId"/>
         </SliceIdTools>
-        <InputHitListName>Input</InputHitListName>
+        <InputHitListName>CaloHitList2D</InputHitListName>
         <InputMCParticleListName>Input</InputMCParticleListName>
         <PassMCParticlesToWorkerInstances>false</PassMCParticlesToWorkerInstances>
         <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>


### PR DESCRIPTION
This PR is needed in order to allow the PreProcessorAlgorithm to cut on the number of hits in an event.  No performance change beyond vetoing certain events with large numbers of hits, cut configurable via xml, default limit std::numeric_limits<int>::max(), is expected.  