### PR TITLE
Update algorithm name LArEventValidation to LArNeutrinoEventValidation.

### DIFF
--- a/settings/PandoraSettings_Master_DUNEFD.xml
+++ b/settings/PandoraSettings_Master_DUNEFD.xml
@@ -39,7 +39,7 @@
         <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
     </algorithm>
 
-    <algorithm type = "LArEventValidation">
+    <algorithm type = "LArNeutrinoEventValidation">
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <MCParticleListName>Input</MCParticleListName>
         <PfoListName>RecreatedPfos</PfoListName>

--- a/settings/PandoraSettings_Master_ICARUS.xml
+++ b/settings/PandoraSettings_Master_ICARUS.xml
@@ -48,7 +48,7 @@
         <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
     </algorithm>
 
-    <algorithm type = "LArEventValidation">
+    <algorithm type = "LArNeutrinoEventValidation">
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <MCParticleListName>Input</MCParticleListName>
         <PfoListName>RecreatedPfos</PfoListName>

--- a/settings/PandoraSettings_Master_MicroBooNE.xml
+++ b/settings/PandoraSettings_Master_MicroBooNE.xml
@@ -44,7 +44,7 @@
         <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
     </algorithm>
 
-    <algorithm type = "LArEventValidation">
+    <algorithm type = "LArNeutrinoEventValidation">
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <MCParticleListName>Input</MCParticleListName>
         <PfoListName>RecreatedPfos</PfoListName>

--- a/settings/PandoraSettings_Master_SBND.xml
+++ b/settings/PandoraSettings_Master_SBND.xml
@@ -41,7 +41,7 @@
         <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
     </algorithm>
 
-    <algorithm type = "LArEventValidation">
+    <algorithm type = "LArNeutrinoEventValidation">
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <MCParticleListName>Input</MCParticleListName>
         <PfoListName>RecreatedPfos</PfoListName>

--- a/settings/PandoraSettings_Master_Standard.xml
+++ b/settings/PandoraSettings_Master_Standard.xml
@@ -41,7 +41,7 @@
         <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
     </algorithm>
 
-    <algorithm type = "LArEventValidation">
+    <algorithm type = "LArNeutrinoEventValidation">
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <MCParticleListName>Input</MCParticleListName>
         <PfoListName>RecreatedPfos</PfoListName>

--- a/settings/development/PandoraSettings_Cheat.xml
+++ b/settings/development/PandoraSettings_Cheat.xml
@@ -217,7 +217,7 @@
         <PfoListName>OutputParticles3D</PfoListName>
     </algorithm>
 
-    <algorithm type = "LArEventValidation">
+    <algorithm type = "LArNeutrinoEventValidation">
         <CaloHitListName>CRCaloHitList2D</CaloHitListName>
         <MCParticleListName>Input</MCParticleListName>
         <PfoListName>OutputParticles3D</PfoListName>


### PR DESCRIPTION
We should make this change clear to anyone running Pandora metrics for Neutrino experiments as it will mean that any old xml scripts will require updating to work once this feature has been merged into LArContent. 

Cheers
Steve