### PR TITLE
Feature/new far detector neutrino reco configuration

### DIFF
--- a/settings/PandoraSettings_Cosmic_ProtoDUNE_DP.xml
+++ b/settings/PandoraSettings_Cosmic_ProtoDUNE_DP.xml
@@ -101,6 +101,7 @@
       <InputClusterListName2>ClustersV</InputClusterListName2>
       <OutputPfoListName>MuonParticles3D</OutputPfoListName>
       <TrackTools>
+        <tool type = "LArTwoViewThreeDKink"/>
         <tool type = "LArTwoViewClearTracks">
           <MinMatchingScore>0.95</MinMatchingScore>
           <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>

--- a/settings/PandoraSettings_Master_ProtoDUNE.xml
+++ b/settings/PandoraSettings_Master_ProtoDUNE.xml
@@ -34,7 +34,7 @@
         <SliceIdTools>
             <tool type = "LArBdtBeamParticleId">
                 <BdtName>ProtoDUNESP_BeamParticleId</BdtName>
-                <BdtFileName>PandoraBdt_v03_20_00.xml</BdtFileName>
+                <BdtFileName>PandoraBdt_BeamParticleId_ProtoDUNESP_v03_24_00.xml</BdtFileName>
                 <MinAdaBDTScore>-0.225</MinAdaBDTScore>
             </tool>
         </SliceIdTools>

--- a/settings/PandoraSettings_Master_ProtoDUNE_DP.xml
+++ b/settings/PandoraSettings_Master_ProtoDUNE_DP.xml
@@ -34,7 +34,7 @@
         <SliceIdTools>
             <tool type = "LArBdtBeamParticleId">
                 <BdtName>ProtoDUNESP_BeamParticleId</BdtName>
-                <BdtFileName>PandoraBdt_v03_20_00.xml</BdtFileName>
+                <BdtFileName>PandoraBdt_BeamParticleId_ProtoDUNESP_v03_24_00.xml</BdtFileName>
                 <MinAdaBDTScore>-0.225</MinAdaBDTScore>
             </tool>
         </SliceIdTools>

--- a/settings/PandoraSettings_Neutrino_DUNEFD.xml
+++ b/settings/PandoraSettings_Neutrino_DUNEFD.xml
@@ -1,6 +1,6 @@
 <pandora>
     <!-- GLOBAL SETTINGS -->
-    <IsMonitoringEnabled>false</IsMonitoringEnabled>
+    <IsMonitoringEnabled>true</IsMonitoringEnabled>
     <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
     <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
 
@@ -161,8 +161,6 @@
         <algorithm type = "LArSimpleClusterCreation" description = "ClusterRebuilding"/>
     </algorithm>
 
-
-
     <!-- ThreeDShowerAlgorithms -->
     <algorithm type = "LArCutPfoCharacterisation">
         <TrackPfoListName>TrackParticles3D</TrackPfoListName>
@@ -197,119 +195,92 @@
         </ShowerTools>
     </algorithm>
 
-<!--2 view Calo matching run "out of the box" for showers - U V -->
-  <algorithm type = "LArTwoViewTransverseTracks">
-   <InputClusterListName1>ClustersU</InputClusterListName1>
-   <InputClusterListName2>ClustersV</InputClusterListName2>
-   <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
-   <LocalMatchingScoreThreshold>0.90</LocalMatchingScoreThreshold>
-   <!--DownsampleFactor>1</DownsampleFactor-->
-   <!--MinOverallLocallyMatchedFraction>0.1f</MinOverallLocallyMatchedFraction-->
-   <DisplayPotentialMatches>false</DisplayPotentialMatches>
-   <MinSamples>13</MinSamples>
-   <TrackTools>
-    <tool type = "LArTwoViewThreeDKink"/>
-    <tool type = "LArTwoViewClearTracks">
-     <MinMatchingScore>0.95</MinMatchingScore>
-     <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
-     <PrintIfMatch>false</PrintIfMatch>
-    </tool>
-    <tool type = "LArTwoViewClearTracks">
-     <MinMatchingScore>0.0</MinMatchingScore>
-     <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
-     <PrintIfMatch>false</PrintIfMatch>
-    </tool>
-    <tool type = "LArTwoViewLongTracks">
-     <MinMatchingScore>0.0</MinMatchingScore>
-     <MinMatchedFraction>0.30</MinMatchedFraction>
-     <PrintIfMatch>false</PrintIfMatch>
-    </tool>
-    <tool type = "LArTwoViewLongTracks">
-     <MinMatchingScore>0.95</MinMatchingScore>
-     <MinMatchedFraction>0.0</MinMatchedFraction>
-     <PrintIfMatch>false</PrintIfMatch>
-    </tool>
-    <tool type = "LArTwoViewSimpleTracks">
-     <PrintIfMatch>true</PrintIfMatch>
-    </tool>
-   </TrackTools>
-  </algorithm>
+    <!-- TwoViewTrackAlgorithms out-of-the-box for showers - U and V -->
+    <algorithm type = "LArTwoViewTransverseTracks">
+        <InputClusterListName1>ClustersU</InputClusterListName1>
+        <InputClusterListName2>ClustersV</InputClusterListName2>
+        <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+        <LocalMatchingScoreThreshold>0.90</LocalMatchingScoreThreshold>
+        <MinSamples>13</MinSamples>
+        <TrackTools>
+            <tool type = "LArTwoViewThreeDKink"/>
+            <tool type = "LArTwoViewClearTracks">
+                <MinMatchingScore>0.95</MinMatchingScore>
+                <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewClearTracks">
+                <MinMatchingScore>0.0</MinMatchingScore>
+                <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewLongTracks">
+                <MinMatchingScore>0.0</MinMatchingScore>
+                <MinMatchedFraction>0.30</MinMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewLongTracks">
+                <MinMatchingScore>0.95</MinMatchingScore>
+                <MinMatchedFraction>0.0</MinMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewSimpleTracks"/>
+        </TrackTools>
+    </algorithm>
 
-<!--2 view Calo matching run "out of the box" for showers - U W -->
-  <algorithm type = "LArTwoViewTransverseTracks">
-   <InputClusterListName1>ClustersU</InputClusterListName1>
-   <InputClusterListName2>ClustersW</InputClusterListName2>
-   <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
-   <LocalMatchingScoreThreshold>0.90</LocalMatchingScoreThreshold>
-   <!--DownsampleFactor>1</DownsampleFactor-->
-   <!--MinOverallLocallyMatchedFraction>0.1f</MinOverallLocallyMatchedFraction-->
-   <DisplayPotentialMatches>false</DisplayPotentialMatches>
-   <MinSamples>13</MinSamples>
-   <TrackTools>
-    <tool type = "LArTwoViewThreeDKink"/>
-    <tool type = "LArTwoViewClearTracks">
-     <MinMatchingScore>0.95</MinMatchingScore>
-     <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
-     <PrintIfMatch>false</PrintIfMatch>
-    </tool>
-    <tool type = "LArTwoViewClearTracks">
-     <MinMatchingScore>0.0</MinMatchingScore>
-     <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
-     <PrintIfMatch>false</PrintIfMatch>
-    </tool>
-    <tool type = "LArTwoViewLongTracks">
-     <MinMatchingScore>0.0</MinMatchingScore>
-     <MinMatchedFraction>0.30</MinMatchedFraction>
-     <PrintIfMatch>false</PrintIfMatch>
-    </tool>
-    <tool type = "LArTwoViewLongTracks">
-     <MinMatchingScore>0.95</MinMatchingScore>
-     <MinMatchedFraction>0.0</MinMatchedFraction>
-     <PrintIfMatch>false</PrintIfMatch>
-    </tool>
-    <tool type = "LArTwoViewSimpleTracks">
-     <PrintIfMatch>true</PrintIfMatch>
-    </tool>
-   </TrackTools>
-  </algorithm>
+    <!-- TwoViewTrackAlgorithms out-of-the-box for showers - U and W -->
+    <algorithm type = "LArTwoViewTransverseTracks">
+        <InputClusterListName1>ClustersU</InputClusterListName1>
+        <InputClusterListName2>ClustersW</InputClusterListName2>
+        <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+        <LocalMatchingScoreThreshold>0.90</LocalMatchingScoreThreshold>
+        <MinSamples>13</MinSamples>
+        <TrackTools>
+            <tool type = "LArTwoViewThreeDKink"/>
+            <tool type = "LArTwoViewClearTracks">
+                <MinMatchingScore>0.95</MinMatchingScore>
+                <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewClearTracks">
+                <MinMatchingScore>0.0</MinMatchingScore>
+                <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewLongTracks">
+                <MinMatchingScore>0.0</MinMatchingScore>
+                <MinMatchedFraction>0.30</MinMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewLongTracks">
+                <MinMatchingScore>0.95</MinMatchingScore>
+                <MinMatchedFraction>0.0</MinMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewSimpleTracks"/>
+        </TrackTools>
+    </algorithm>
 
-<!--2 view Calo matching run "out of the box" for showers - V W -->
-  <algorithm type = "LArTwoViewTransverseTracks">
-   <InputClusterListName1>ClustersV</InputClusterListName1>
-   <InputClusterListName2>ClustersW</InputClusterListName2>
-   <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
-   <LocalMatchingScoreThreshold>0.90</LocalMatchingScoreThreshold>
-   <!--DownsampleFactor>1</DownsampleFactor-->
-   <!--MinOverallLocallyMatchedFraction>0.1f</MinOverallLocallyMatchedFraction-->
-   <DisplayPotentialMatches>false</DisplayPotentialMatches>
-   <MinSamples>13</MinSamples>
-   <TrackTools>
-    <tool type = "LArTwoViewThreeDKink"/>
-    <tool type = "LArTwoViewClearTracks">
-     <MinMatchingScore>0.95</MinMatchingScore>
-     <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
-     <PrintIfMatch>false</PrintIfMatch>
-    </tool>
-    <tool type = "LArTwoViewClearTracks">
-     <MinMatchingScore>0.0</MinMatchingScore>
-     <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
-     <PrintIfMatch>false</PrintIfMatch>
-    </tool>
-    <tool type = "LArTwoViewLongTracks">
-     <MinMatchingScore>0.0</MinMatchingScore>
-     <MinMatchedFraction>0.30</MinMatchedFraction>
-     <PrintIfMatch>false</PrintIfMatch>
-    </tool>
-    <tool type = "LArTwoViewLongTracks">
-     <MinMatchingScore>0.95</MinMatchingScore>
-     <MinMatchedFraction>0.0</MinMatchedFraction>
-     <PrintIfMatch>false</PrintIfMatch>
-    </tool>
-    <tool type = "LArTwoViewSimpleTracks">
-     <PrintIfMatch>true</PrintIfMatch>
-    </tool>
-   </TrackTools>
-  </algorithm>
+    <!-- TwoViewTrackAlgorithms out-of-the-box for showers - V and W -->
+    <algorithm type = "LArTwoViewTransverseTracks">
+        <InputClusterListName1>ClustersV</InputClusterListName1>
+        <InputClusterListName2>ClustersW</InputClusterListName2>
+        <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+        <LocalMatchingScoreThreshold>0.90</LocalMatchingScoreThreshold>
+        <MinSamples>13</MinSamples>
+        <TrackTools>
+            <tool type = "LArTwoViewThreeDKink"/>
+            <tool type = "LArTwoViewClearTracks">
+                <MinMatchingScore>0.95</MinMatchingScore>
+                <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewClearTracks">
+                <MinMatchingScore>0.0</MinMatchingScore>
+                <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewLongTracks">
+                <MinMatchingScore>0.0</MinMatchingScore>
+                <MinMatchedFraction>0.30</MinMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewLongTracks">
+                <MinMatchingScore>0.95</MinMatchingScore>
+                <MinMatchedFraction>0.0</MinMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewSimpleTracks"/>
+        </TrackTools>
+    </algorithm>
 
     <!-- Repeat ThreeDTrackAlgorithms -->
     <algorithm type = "LArThreeDTransverseTracks">
@@ -355,90 +326,84 @@
 
     <!-- TwoViewTrackAlgorithms for U and V -->
     <algorithm type = "LArTwoViewTransverseTracks">
-      <InputClusterListName1>ClustersU</InputClusterListName1>
-      <InputClusterListName2>ClustersV</InputClusterListName2>
-      <OutputPfoListName>TrackParticles3D</OutputPfoListName>
-      <TrackTools>
-        <tool type = "LArTwoViewThreeDKink"/>
-        <tool type = "LArTwoViewClearTracks">
-          <MinMatchingScore>0.95</MinMatchingScore>
-          <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
-        </tool>
-        <tool type = "LArTwoViewClearTracks">
-          <MinMatchingScore>0.0</MinMatchingScore>
-          <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
-        </tool>
-        <tool type = "LArTwoViewLongTracks">
-          <MinMatchingScore>0.0</MinMatchingScore>
-          <MinMatchedFraction>0.30</MinMatchedFraction>
-        </tool>
-        <tool type = "LArTwoViewLongTracks">
-          <MinMatchingScore>0.95</MinMatchingScore>
-          <MinMatchedFraction>0.0</MinMatchedFraction>
-        </tool>
-        <tool type = "LArTwoViewSimpleTracks"/>
-      </TrackTools>
+        <InputClusterListName1>ClustersU</InputClusterListName1>
+        <InputClusterListName2>ClustersV</InputClusterListName2>
+        <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <TrackTools>
+            <tool type = "LArTwoViewThreeDKink"/>
+            <tool type = "LArTwoViewClearTracks">
+                <MinMatchingScore>0.95</MinMatchingScore>
+                <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewClearTracks">
+                <MinMatchingScore>0.0</MinMatchingScore>
+                <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewLongTracks">
+                <MinMatchingScore>0.0</MinMatchingScore>
+                <MinMatchedFraction>0.30</MinMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewLongTracks">
+                <MinMatchingScore>0.95</MinMatchingScore>
+                <MinMatchedFraction>0.0</MinMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewSimpleTracks"/>
+        </TrackTools>
     </algorithm>
 
     <!-- TwoViewTrackAlgorithms for U and W -->
     <algorithm type = "LArTwoViewTransverseTracks">
-      <InputClusterListName1>ClustersU</InputClusterListName1>
-      <InputClusterListName2>ClustersW</InputClusterListName2>
-      <OutputPfoListName>TrackParticles3D</OutputPfoListName>
-      <TrackTools>
-        <tool type = "LArTwoViewThreeDKink"/>
-        <tool type = "LArTwoViewClearTracks">
-          <MinMatchingScore>0.95</MinMatchingScore>
-          <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
-        </tool>
-        <tool type = "LArTwoViewClearTracks">
-          <MinMatchingScore>0.0</MinMatchingScore>
-          <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
-        </tool>
-        <tool type = "LArTwoViewLongTracks">
-          <MinMatchingScore>0.0</MinMatchingScore>
-          <MinMatchedFraction>0.30</MinMatchedFraction>
-        </tool>
-        <tool type = "LArTwoViewLongTracks">
-          <MinMatchingScore>0.95</MinMatchingScore>
-          <MinMatchedFraction>0.0</MinMatchedFraction>
-        </tool>
-        <tool type = "LArTwoViewSimpleTracks"/>
-      </TrackTools>
+        <InputClusterListName1>ClustersU</InputClusterListName1>
+        <InputClusterListName2>ClustersW</InputClusterListName2>
+        <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <TrackTools>
+            <tool type = "LArTwoViewThreeDKink"/>
+            <tool type = "LArTwoViewClearTracks">
+                <MinMatchingScore>0.95</MinMatchingScore>
+                <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewClearTracks">
+                <MinMatchingScore>0.0</MinMatchingScore>
+                <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewLongTracks">
+                <MinMatchingScore>0.0</MinMatchingScore>
+                <MinMatchedFraction>0.30</MinMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewLongTracks">
+                <MinMatchingScore>0.95</MinMatchingScore>
+                <MinMatchedFraction>0.0</MinMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewSimpleTracks"/>
+        </TrackTools>
     </algorithm>
 
     <!-- TwoViewTrackAlgorithms for V and W -->
     <algorithm type = "LArTwoViewTransverseTracks">
-      <InputClusterListName1>ClustersV</InputClusterListName1>
-      <InputClusterListName2>ClustersW</InputClusterListName2>
-      <OutputPfoListName>TrackParticles3D</OutputPfoListName>
-      <TrackTools>
-        <tool type = "LArTwoViewThreeDKink"/>
-        <tool type = "LArTwoViewClearTracks">
-          <MinMatchingScore>0.95</MinMatchingScore>
-          <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
-        </tool>
-        <tool type = "LArTwoViewClearTracks">
-          <MinMatchingScore>0.0</MinMatchingScore>
-          <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
-        </tool>
-        <tool type = "LArTwoViewLongTracks">
-          <MinMatchingScore>0.0</MinMatchingScore>
-          <MinMatchedFraction>0.30</MinMatchedFraction>
-        </tool>
-        <tool type = "LArTwoViewLongTracks">
-          <MinMatchingScore>0.95</MinMatchingScore>
-          <MinMatchedFraction>0.0</MinMatchedFraction>
-        </tool>
-        <tool type = "LArTwoViewSimpleTracks"/>
-      </TrackTools>
+        <InputClusterListName1>ClustersV</InputClusterListName1>
+        <InputClusterListName2>ClustersW</InputClusterListName2>
+        <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+        <TrackTools>
+            <tool type = "LArTwoViewThreeDKink"/>
+            <tool type = "LArTwoViewClearTracks">
+                <MinMatchingScore>0.95</MinMatchingScore>
+                <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewClearTracks">
+                <MinMatchingScore>0.0</MinMatchingScore>
+                <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewLongTracks">
+                <MinMatchingScore>0.0</MinMatchingScore>
+                <MinMatchedFraction>0.30</MinMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewLongTracks">
+                <MinMatchingScore>0.95</MinMatchingScore>
+                <MinMatchedFraction>0.0</MinMatchedFraction>
+            </tool>
+            <tool type = "LArTwoViewSimpleTracks"/>
+        </TrackTools>
     </algorithm>
-
-    <!--algorithm type = "LArVisualMonitoring">
-        <ClusterListNames>ClustersU ClustersV ClustersW</ClusterListNames>
-        <ShowCurrentPfos>true</ShowCurrentPfos>
-        <ShowDetector>true</ShowDetector>
-    </algorithm-->
 
     <!-- ThreeDRecoveryAlgorithms -->
     <algorithm type = "LArVertexBasedPfoRecovery">

--- a/settings/PandoraSettings_Neutrino_DUNEFD.xml
+++ b/settings/PandoraSettings_Neutrino_DUNEFD.xml
@@ -1,6 +1,6 @@
 <pandora>
     <!-- GLOBAL SETTINGS -->
-    <IsMonitoringEnabled>true</IsMonitoringEnabled>
+    <IsMonitoringEnabled>false</IsMonitoringEnabled>
     <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
     <SingleHitTypeClusteringMode>true</SingleHitTypeClusteringMode>
 
@@ -161,6 +161,8 @@
         <algorithm type = "LArSimpleClusterCreation" description = "ClusterRebuilding"/>
     </algorithm>
 
+
+
     <!-- ThreeDShowerAlgorithms -->
     <algorithm type = "LArCutPfoCharacterisation">
         <TrackPfoListName>TrackParticles3D</TrackPfoListName>
@@ -194,6 +196,120 @@
             <tool type = "LArSimpleShowers"/>
         </ShowerTools>
     </algorithm>
+
+<!--2 view Calo matching run "out of the box" for showers - U V -->
+  <algorithm type = "LArTwoViewTransverseTracks">
+   <InputClusterListName1>ClustersU</InputClusterListName1>
+   <InputClusterListName2>ClustersV</InputClusterListName2>
+   <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+   <LocalMatchingScoreThreshold>0.90</LocalMatchingScoreThreshold>
+   <!--DownsampleFactor>1</DownsampleFactor-->
+   <!--MinOverallLocallyMatchedFraction>0.1f</MinOverallLocallyMatchedFraction-->
+   <DisplayPotentialMatches>false</DisplayPotentialMatches>
+   <MinSamples>13</MinSamples>
+   <TrackTools>
+    <tool type = "LArTwoViewThreeDKink"/>
+    <tool type = "LArTwoViewClearTracks">
+     <MinMatchingScore>0.95</MinMatchingScore>
+     <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+     <PrintIfMatch>false</PrintIfMatch>
+    </tool>
+    <tool type = "LArTwoViewClearTracks">
+     <MinMatchingScore>0.0</MinMatchingScore>
+     <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+     <PrintIfMatch>false</PrintIfMatch>
+    </tool>
+    <tool type = "LArTwoViewLongTracks">
+     <MinMatchingScore>0.0</MinMatchingScore>
+     <MinMatchedFraction>0.30</MinMatchedFraction>
+     <PrintIfMatch>false</PrintIfMatch>
+    </tool>
+    <tool type = "LArTwoViewLongTracks">
+     <MinMatchingScore>0.95</MinMatchingScore>
+     <MinMatchedFraction>0.0</MinMatchedFraction>
+     <PrintIfMatch>false</PrintIfMatch>
+    </tool>
+    <tool type = "LArTwoViewSimpleTracks">
+     <PrintIfMatch>true</PrintIfMatch>
+    </tool>
+   </TrackTools>
+  </algorithm>
+
+<!--2 view Calo matching run "out of the box" for showers - U W -->
+  <algorithm type = "LArTwoViewTransverseTracks">
+   <InputClusterListName1>ClustersU</InputClusterListName1>
+   <InputClusterListName2>ClustersW</InputClusterListName2>
+   <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+   <LocalMatchingScoreThreshold>0.90</LocalMatchingScoreThreshold>
+   <!--DownsampleFactor>1</DownsampleFactor-->
+   <!--MinOverallLocallyMatchedFraction>0.1f</MinOverallLocallyMatchedFraction-->
+   <DisplayPotentialMatches>false</DisplayPotentialMatches>
+   <MinSamples>13</MinSamples>
+   <TrackTools>
+    <tool type = "LArTwoViewThreeDKink"/>
+    <tool type = "LArTwoViewClearTracks">
+     <MinMatchingScore>0.95</MinMatchingScore>
+     <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+     <PrintIfMatch>false</PrintIfMatch>
+    </tool>
+    <tool type = "LArTwoViewClearTracks">
+     <MinMatchingScore>0.0</MinMatchingScore>
+     <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+     <PrintIfMatch>false</PrintIfMatch>
+    </tool>
+    <tool type = "LArTwoViewLongTracks">
+     <MinMatchingScore>0.0</MinMatchingScore>
+     <MinMatchedFraction>0.30</MinMatchedFraction>
+     <PrintIfMatch>false</PrintIfMatch>
+    </tool>
+    <tool type = "LArTwoViewLongTracks">
+     <MinMatchingScore>0.95</MinMatchingScore>
+     <MinMatchedFraction>0.0</MinMatchedFraction>
+     <PrintIfMatch>false</PrintIfMatch>
+    </tool>
+    <tool type = "LArTwoViewSimpleTracks">
+     <PrintIfMatch>true</PrintIfMatch>
+    </tool>
+   </TrackTools>
+  </algorithm>
+
+<!--2 view Calo matching run "out of the box" for showers - V W -->
+  <algorithm type = "LArTwoViewTransverseTracks">
+   <InputClusterListName1>ClustersV</InputClusterListName1>
+   <InputClusterListName2>ClustersW</InputClusterListName2>
+   <OutputPfoListName>ShowerParticles3D</OutputPfoListName>
+   <LocalMatchingScoreThreshold>0.90</LocalMatchingScoreThreshold>
+   <!--DownsampleFactor>1</DownsampleFactor-->
+   <!--MinOverallLocallyMatchedFraction>0.1f</MinOverallLocallyMatchedFraction-->
+   <DisplayPotentialMatches>false</DisplayPotentialMatches>
+   <MinSamples>13</MinSamples>
+   <TrackTools>
+    <tool type = "LArTwoViewThreeDKink"/>
+    <tool type = "LArTwoViewClearTracks">
+     <MinMatchingScore>0.95</MinMatchingScore>
+     <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+     <PrintIfMatch>false</PrintIfMatch>
+    </tool>
+    <tool type = "LArTwoViewClearTracks">
+     <MinMatchingScore>0.0</MinMatchingScore>
+     <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+     <PrintIfMatch>false</PrintIfMatch>
+    </tool>
+    <tool type = "LArTwoViewLongTracks">
+     <MinMatchingScore>0.0</MinMatchingScore>
+     <MinMatchedFraction>0.30</MinMatchedFraction>
+     <PrintIfMatch>false</PrintIfMatch>
+    </tool>
+    <tool type = "LArTwoViewLongTracks">
+     <MinMatchingScore>0.95</MinMatchingScore>
+     <MinMatchedFraction>0.0</MinMatchedFraction>
+     <PrintIfMatch>false</PrintIfMatch>
+    </tool>
+    <tool type = "LArTwoViewSimpleTracks">
+     <PrintIfMatch>true</PrintIfMatch>
+    </tool>
+   </TrackTools>
+  </algorithm>
 
     <!-- Repeat ThreeDTrackAlgorithms -->
     <algorithm type = "LArThreeDTransverseTracks">
@@ -236,6 +352,93 @@
         </TrackTools>
         <algorithm type = "LArSimpleClusterCreation" description = "ClusterRebuilding"/>
     </algorithm>
+
+    <!-- TwoViewTrackAlgorithms for U and V -->
+    <algorithm type = "LArTwoViewTransverseTracks">
+      <InputClusterListName1>ClustersU</InputClusterListName1>
+      <InputClusterListName2>ClustersV</InputClusterListName2>
+      <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+      <TrackTools>
+        <tool type = "LArTwoViewThreeDKink"/>
+        <tool type = "LArTwoViewClearTracks">
+          <MinMatchingScore>0.95</MinMatchingScore>
+          <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewClearTracks">
+          <MinMatchingScore>0.0</MinMatchingScore>
+          <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewLongTracks">
+          <MinMatchingScore>0.0</MinMatchingScore>
+          <MinMatchedFraction>0.30</MinMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewLongTracks">
+          <MinMatchingScore>0.95</MinMatchingScore>
+          <MinMatchedFraction>0.0</MinMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewSimpleTracks"/>
+      </TrackTools>
+    </algorithm>
+
+    <!-- TwoViewTrackAlgorithms for U and W -->
+    <algorithm type = "LArTwoViewTransverseTracks">
+      <InputClusterListName1>ClustersU</InputClusterListName1>
+      <InputClusterListName2>ClustersW</InputClusterListName2>
+      <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+      <TrackTools>
+        <tool type = "LArTwoViewThreeDKink"/>
+        <tool type = "LArTwoViewClearTracks">
+          <MinMatchingScore>0.95</MinMatchingScore>
+          <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewClearTracks">
+          <MinMatchingScore>0.0</MinMatchingScore>
+          <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewLongTracks">
+          <MinMatchingScore>0.0</MinMatchingScore>
+          <MinMatchedFraction>0.30</MinMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewLongTracks">
+          <MinMatchingScore>0.95</MinMatchingScore>
+          <MinMatchedFraction>0.0</MinMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewSimpleTracks"/>
+      </TrackTools>
+    </algorithm>
+
+    <!-- TwoViewTrackAlgorithms for V and W -->
+    <algorithm type = "LArTwoViewTransverseTracks">
+      <InputClusterListName1>ClustersV</InputClusterListName1>
+      <InputClusterListName2>ClustersW</InputClusterListName2>
+      <OutputPfoListName>TrackParticles3D</OutputPfoListName>
+      <TrackTools>
+        <tool type = "LArTwoViewThreeDKink"/>
+        <tool type = "LArTwoViewClearTracks">
+          <MinMatchingScore>0.95</MinMatchingScore>
+          <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewClearTracks">
+          <MinMatchingScore>0.0</MinMatchingScore>
+          <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewLongTracks">
+          <MinMatchingScore>0.0</MinMatchingScore>
+          <MinMatchedFraction>0.30</MinMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewLongTracks">
+          <MinMatchingScore>0.95</MinMatchingScore>
+          <MinMatchedFraction>0.0</MinMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewSimpleTracks"/>
+      </TrackTools>
+    </algorithm>
+
+    <!--algorithm type = "LArVisualMonitoring">
+        <ClusterListNames>ClustersU ClustersV ClustersW</ClusterListNames>
+        <ShowCurrentPfos>true</ShowCurrentPfos>
+        <ShowDetector>true</ShowDetector>
+    </algorithm-->
 
     <!-- ThreeDRecoveryAlgorithms -->
     <algorithm type = "LArVertexBasedPfoRecovery">
@@ -319,7 +522,99 @@
         <AddHitsAsIsolated>true</AddHitsAsIsolated>
     </algorithm>
 
-    <!-- NeutrinoAlgorithms -->
+    <algorithm type = "LArBdtPfoCharacterisation">
+        <TrackPfoListName>TrackParticles3D</TrackPfoListName>
+        <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
+        <MCParticleListName>Input</MCParticleListName>
+        <CaloHitListName>CaloHitList2D</CaloHitListName>
+        <UseThreeDInformation>true</UseThreeDInformation>
+        <MvaFileName>PandoraBdt_v03_20_00.xml</MvaFileName>
+        <MvaName>PfoCharacterisation</MvaName>
+        <MvaFileNameNoChargeInfo>PandoraBdt_v03_20_00.xml</MvaFileNameNoChargeInfo>
+        <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
+        <TrainingSetMode>false</TrainingSetMode>
+        <TrainingOutputFileName>training_output</TrainingOutputFileName>
+        <FeatureTools>
+            <tool type = "LArThreeDLinearFitFeatureTool"/>
+            <tool type = "LArThreeDVertexDistanceFeatureTool"/>
+            <tool type = "LArThreeDPCAFeatureTool"/>
+            <tool type = "LArPfoHierarchyFeatureTool"/>
+            <tool type = "LArThreeDOpeningAngleFeatureTool">
+                <HitFraction>0.2</HitFraction>
+            </tool>
+            <tool type = "LArThreeDChargeFeatureTool"/>
+        </FeatureTools>
+        <FeatureToolsNoChargeInfo>
+            <tool type = "LArThreeDLinearFitFeatureTool"/>
+            <tool type = "LArThreeDVertexDistanceFeatureTool"/>
+            <tool type = "LArThreeDPCAFeatureTool"/>
+            <tool type = "LArPfoHierarchyFeatureTool"/>
+            <tool type = "LArThreeDOpeningAngleFeatureTool">
+                <HitFraction>0.2</HitFraction>
+            </tool>
+        </FeatureToolsNoChargeInfo>
+        <WriteToTree>false</WriteToTree>
+        <OutputTree>tree</OutputTree>
+        <OutputFile>tree.root</OutputFile>
+    </algorithm>
+
+    <!-- Recursively Repeat MopUpAlgorithms -->
+    <algorithm type = "LArRecursivePfoMopUp">
+        <PfoListNames>TrackParticles3D ShowerParticles3D</PfoListNames>
+        <MaxIterations>10</MaxIterations>
+        <MopUpAlgorithms>
+            <algorithm type = "LArBoundedClusterMopUp">
+                <PfoListNames>ShowerParticles3D</PfoListNames>
+                <DaughterListNames>ClustersU ClustersV ClustersW</DaughterListNames>
+            </algorithm>
+            <algorithm type = "LArConeClusterMopUp">
+                <PfoListNames>ShowerParticles3D</PfoListNames>
+                <DaughterListNames>ClustersU ClustersV ClustersW</DaughterListNames>
+            </algorithm>
+            <algorithm type = "LArNearbyClusterMopUp">
+                <PfoListNames>ShowerParticles3D</PfoListNames>
+                <DaughterListNames>ClustersU ClustersV ClustersW</DaughterListNames>
+            </algorithm>
+            <algorithm type = "LArSlidingConePfoMopUp">
+                <InputPfoListNames>TrackParticles3D ShowerParticles3D</InputPfoListNames>
+                <DaughterListNames>ClustersU ClustersV ClustersW TrackClusters3D ShowerClusters3D</DaughterListNames>
+            </algorithm>
+            <algorithm type = "LArSlidingConeClusterMopUp">
+                <InputPfoListNames>TrackParticles3D ShowerParticles3D</InputPfoListNames>
+                <DaughterListNames>ClustersU ClustersV ClustersW</DaughterListNames>
+            </algorithm>
+            <algorithm type = "LArPfoHitCleaning">
+                <PfoListNames>TrackParticles3D ShowerParticles3D</PfoListNames>
+                <ClusterListNames>TrackClusters3D ShowerClusters3D</ClusterListNames>
+            </algorithm>
+            <algorithm type = "LArThreeDHitCreation">
+                <InputPfoListName>TrackParticles3D</InputPfoListName>
+                <OutputCaloHitListName>TrackCaloHits3D</OutputCaloHitListName>
+                <OutputClusterListName>TrackClusters3D</OutputClusterListName>
+                <HitCreationTools>
+                    <tool type = "LArClearTransverseTrackHits"><MinViews>3</MinViews></tool>
+                    <tool type = "LArClearLongitudinalTrackHits"><MinViews>3</MinViews></tool>
+                    <tool type = "LArMultiValuedLongitudinalTrackHits"><MinViews>3</MinViews></tool>
+                    <tool type = "LArMultiValuedTransverseTrackHits"><MinViews>3</MinViews></tool>
+                    <tool type = "LArClearTransverseTrackHits"><MinViews>2</MinViews></tool>
+                    <tool type = "LArClearLongitudinalTrackHits"><MinViews>2</MinViews></tool>
+                    <tool type = "LArMultiValuedLongitudinalTrackHits"><MinViews>2</MinViews></tool>
+                </HitCreationTools>
+            </algorithm>
+            <algorithm type = "LArThreeDHitCreation">
+                <InputPfoListName>ShowerParticles3D</InputPfoListName>
+                <OutputCaloHitListName>ShowerCaloHits3D</OutputCaloHitListName>
+                <OutputClusterListName>ShowerClusters3D</OutputClusterListName>
+                <HitCreationTools>
+                    <tool type = "LArThreeViewShowerHits"/>
+                    <tool type = "LArTwoViewShowerHits"/>
+                    <tool type = "LArDeltaRayShowerHits"/>
+                </HitCreationTools>
+            </algorithm>
+        </MopUpAlgorithms>
+    </algorithm>
+
+    <!-- Neutrino creation and hierarchy building -->
     <algorithm type = "LArNeutrinoCreation">
        <InputVertexListName>NeutrinoVertices3D</InputVertexListName>
        <NeutrinoPfoListName>NeutrinoParticles3D</NeutrinoPfoListName>
@@ -373,6 +668,11 @@
         <WriteToTree>false</WriteToTree>
         <OutputTree>tree</OutputTree>
         <OutputFile>tree.root</OutputFile>
+    </algorithm>
+
+    <algorithm type = "LArShowerHierarchyMopUp">
+        <LeadingPfoListName>NeutrinoParticles3D</LeadingPfoListName>
+        <DaughterListNames>TrackParticles3D ShowerParticles3D DaughterVertices3D ClustersU ClustersV ClustersW TrackClusters3D ShowerClusters3D</DaughterListNames>
     </algorithm>
 
     <algorithm type = "LArNeutrinoProperties">

--- a/settings/PandoraSettings_Neutrino_DUNEFD.xml
+++ b/settings/PandoraSettings_Neutrino_DUNEFD.xml
@@ -100,7 +100,7 @@
         <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
         <OutputVertexListName>NeutrinoVertices3D</OutputVertexListName>
         <ReplaceCurrentVertexList>true</ReplaceCurrentVertexList>
-        <MvaFileName>PandoraBdt_v03_20_00.xml</MvaFileName>
+        <MvaFileName>PandoraBdt_Vertexing_DUNEFD_v03_24_00.xml</MvaFileName>
         <RegionMvaName>DUNEFD_VertexSelectionRegion</RegionMvaName>
         <VertexMvaName>DUNEFD_VertexSelectionVertex</VertexMvaName>
         <FeatureTools>
@@ -493,9 +493,9 @@
         <MCParticleListName>Input</MCParticleListName>
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <UseThreeDInformation>true</UseThreeDInformation>
-        <MvaFileName>PandoraBdt_v03_20_00.xml</MvaFileName>
+        <MvaFileName>PandoraBdt_PfoCharacterisation_DUNEFD_v03_24_00.xml</MvaFileName>
         <MvaName>PfoCharacterisation</MvaName>
-        <MvaFileNameNoChargeInfo>PandoraBdt_v03_20_00.xml</MvaFileNameNoChargeInfo>
+        <MvaFileNameNoChargeInfo>PandoraBdt_PfoCharacterisation_DUNEFD_v03_24_00.xml</MvaFileNameNoChargeInfo>
         <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>
@@ -605,9 +605,9 @@
         <MCParticleListName>Input</MCParticleListName>
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <UseThreeDInformation>true</UseThreeDInformation>
-        <MvaFileName>PandoraBdt_v03_20_00.xml</MvaFileName>
+        <MvaFileName>PandoraBdt_PfoCharacterisation_DUNEFD_v03_24_00.xml</MvaFileName>
         <MvaName>PfoCharacterisation</MvaName>
-        <MvaFileNameNoChargeInfo>PandoraBdt_v03_20_00.xml</MvaFileNameNoChargeInfo>
+        <MvaFileNameNoChargeInfo>PandoraBdt_PfoCharacterisation_DUNEFD_v03_24_00.xml</MvaFileNameNoChargeInfo>
         <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>

--- a/settings/PandoraSettings_TestBeam_ProtoDUNE.xml
+++ b/settings/PandoraSettings_TestBeam_ProtoDUNE.xml
@@ -94,7 +94,7 @@
         <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
         <OutputVertexListName>NeutrinoVertices3D</OutputVertexListName>
         <ReplaceCurrentVertexList>true</ReplaceCurrentVertexList>
-        <MvaFileName>PandoraBdt_v03_20_00.xml</MvaFileName>
+        <MvaFileName>PandoraBdt_Vertexing_ProtoDUNESP_v03_24_00.xml</MvaFileName>
         <RegionMvaName>ProtoDUNE_VertexSelectionRegion</RegionMvaName>
         <VertexMvaName>ProtoDUNE_VertexSelectionVertex</VertexMvaName>
         <TestBeamMode>true</TestBeamMode>
@@ -340,9 +340,9 @@
         <MCParticleListName>Input</MCParticleListName>
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <UseThreeDInformation>true</UseThreeDInformation>
-        <MvaFileName>PandoraBdt_ProtoDUNE_v03_20_00.xml</MvaFileName>
+        <MvaFileName>PandoraBdt_PfoCharacterisation_ProtoDUNESP_v03_24_00.xml</MvaFileName>
         <MvaName>PfoCharacterisation</MvaName>
-        <MvaFileNameNoChargeInfo>PandoraBdt_ProtoDUNE_v03_20_00.xml</MvaFileNameNoChargeInfo>
+        <MvaFileNameNoChargeInfo>PandoraBdt_PfoCharacterisation_ProtoDUNESP_v03_24_00.xml</MvaFileNameNoChargeInfo>
         <MvaNameNoChargeInfo>PfoCharacterisationNoChargeInfo</MvaNameNoChargeInfo>
         <TrainingSetMode>false</TrainingSetMode>
         <TrainingOutputFileName>training_output</TrainingOutputFileName>

--- a/settings/PandoraSettings_TestBeam_ProtoDUNE_DP.xml
+++ b/settings/PandoraSettings_TestBeam_ProtoDUNE_DP.xml
@@ -124,7 +124,24 @@
       <InputClusterListName2>ClustersV</InputClusterListName2>
       <OutputPfoListName>TrackParticles3D</OutputPfoListName>
       <TrackTools>
-        <tool type = "LArTwoViewClearTracks"/>
+        <tool type = "LArTwoViewThreeDKink"/>
+        <tool type = "LArTwoViewClearTracks">
+          <MinMatchingScore>0.95</MinMatchingScore>
+          <MinLocallyMatchedFraction>0.0</MinLocallyMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewClearTracks">
+          <MinMatchingScore>0.0</MinMatchingScore>
+          <MinLocallyMatchedFraction>0.30</MinLocallyMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewLongTracks">
+          <MinMatchingScore>0.0</MinMatchingScore>
+          <MinMatchedFraction>0.30</MinMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewLongTracks">
+          <MinMatchingScore>0.95</MinMatchingScore>
+          <MinMatchedFraction>0.0</MinMatchedFraction>
+        </tool>
+        <tool type = "LArTwoViewSimpleTracks"/>
       </TrackTools>
     </algorithm>
 

--- a/settings/PandoraSettings_TestBeam_ProtoDUNE_DP.xml
+++ b/settings/PandoraSettings_TestBeam_ProtoDUNE_DP.xml
@@ -98,7 +98,7 @@
         <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
         <OutputVertexListName>NeutrinoVertices3D</OutputVertexListName>
         <ReplaceCurrentVertexList>true</ReplaceCurrentVertexList>
-        <MvaFileName>PandoraBdt_v03_20_00.xml</MvaFileName>
+        <MvaFileName>PandoraBdt_Vertexing_ProtoDUNESP_v03_24_00.xml</MvaFileName>
         <RegionMvaName>ProtoDUNE_VertexSelectionRegion</RegionMvaName>
         <VertexMvaName>ProtoDUNE_VertexSelectionVertex</VertexMvaName>
         <TestBeamMode>true</TestBeamMode>


### PR DESCRIPTION
This PR adds new algorithms and tools to the DUNEFD Neutrino XML settings file. In particular, the PR adds:
- Pair-wise two-view calorimetric matching for tracks
- An initial version of the two-view calorimetric matching for showers
- Iterative shower growing
- Shower hierarchy mopup

Additionally, this PR points DUNEFD, ProtoDUNE-SP and ProtoDUNE-DP to new BDT files, obtained by splitting the existing Pandora BDT files into different files for each BDT type and detectors. The DUNEFD vertexing BDT has been recently retrained. More detail in the related [LArMachineLearning data PR](https://github.com/PandoraPFA/LArMachineLearningData/pull/22). 

