### PR TITLE
Updates to BdtVertexSelectionAlgorithm settings in streamed neutrino reco XML

### DIFF
--- a/settings/development/PandoraSettings_Streaming_Neutrino_DUNEFD.xml
+++ b/settings/development/PandoraSettings_Streaming_Neutrino_DUNEFD.xml
@@ -205,7 +205,10 @@
             <tool type = "LArGlobalAsymmetryFeature"/>
             <tool type = "LArShowerAsymmetryFeature"/>
             <tool type = "LArRPhiFeature"/>
+            <tool type = "LArEnergyDepositionAsymmetryFeature"/>
         </FeatureTools>
+        <LegacyEventShapes>false</LegacyEventShapes>
+        <LegacyVariables>false</LegacyVariables>
     </algorithm>
     <algorithm type = "LArDLClusterCharacterisation">
         <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>


### PR DESCRIPTION
This is a small PR that just adds a couple of changes to the BdtVertexSelectionAlgorithm settings in the streamed reconstruction neutrino XML, in line with recent changes to the standard DUNEFD neutrino reco XML. Without these changes, the streamed reconstruction currently breaks - this PR fixes that.