### PR TITLE
Add MC neutrino info for edep-reco branch

### DIFF
--- a/include/PandoraInterface.h
+++ b/include/PandoraInterface.h
@@ -426,6 +426,17 @@ MCParticleEnergyMap CreateMCParticles(const TG4Event &event, const pandora::Pand
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 /**
+ *  @brief  Convert the GENIE neutrino reaction string to a Nuance-like integer code
+ *
+ *  @param  reaction The neutrino reaction string
+ *
+ *  @return The reaction integer code
+ */
+int GetNuanceCode(const std::string &reaction);
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+/**
  *  @brief  Make voxels from a given TG4HitSegment (a Geant4 energy deposition step)
  *
  *  @param  g4Hit The TG4HitSegment

--- a/include/PandoraInterface.h
+++ b/include/PandoraInterface.h
@@ -44,6 +44,15 @@ public:
     bool m_shouldDisplayEventNumber; ///< Whether event numbers should be
                                      ///< displayed (default false)
 
+    bool m_shouldRunAllHitsCosmicReco;  ///< Whether to run all hits cosmic-ray reconstruction
+    bool m_shouldRunStitching;          ///< Whether to stitch cosmic-ray muons crossing between volumes
+    bool m_shouldRunCosmicHitRemoval;   ///< Whether to remove hits from tagged cosmic-rays
+    bool m_shouldRunSlicing;            ///< Whether to slice events into separate regions for processing
+    bool m_shouldRunNeutrinoRecoOption; ///< Whether to run neutrino reconstruction for each slice
+    bool m_shouldRunCosmicRecoOption;   ///< Whether to run cosmic-ray reconstruction for each slice
+    bool m_shouldPerformSliceId;        ///< Whether to identify slices and select most appropriate pfos
+    bool m_printOverallRecoStatus;      ///< Whether to print current operation status messages
+
     int m_nEventsToSkip; ///< The number of events to skip
 
     bool m_use3D;     ///< Create 3D LArCaloHits
@@ -63,6 +72,14 @@ inline Parameters::Parameters() :
     m_inputFileName(""),
     m_nEventsToProcess(-1),
     m_shouldDisplayEventNumber(false),
+    m_shouldRunAllHitsCosmicReco(true),
+    m_shouldRunStitching(true),
+    m_shouldRunCosmicHitRemoval(true),
+    m_shouldRunSlicing(true),
+    m_shouldRunNeutrinoRecoOption(true),
+    m_shouldRunCosmicRecoOption(true),
+    m_shouldPerformSliceId(true),
+    m_printOverallRecoStatus(false),
     m_nEventsToSkip(0),
     m_use3D(true),
     m_useLArTPC(false),
@@ -443,16 +460,12 @@ LArVoxelList MergeSameVoxels(const LArVoxelList &voxelList);
  */
 bool ParseCommandLine(int argc, char *argv[], Parameters &parameters);
 
-//------------------------------------------------------------------------------------------------------------------------------------------
-
 /**
  *  @brief  Print the list of configurable options
  *
  *  @return false, to force abort
  */
 bool PrintOptions();
-
-//------------------------------------------------------------------------------------------------------------------------------------------
 
 /**
  *  @brief  Process view option so that 3x2D and/or 3D hit lists are created
@@ -462,6 +475,24 @@ bool PrintOptions();
  *
  */
 void ProcessViewOption(const std::string &viewOption, Parameters &parameters);
+
+/**
+ *  @brief  Process the provided reco option string to perform high-level steering
+ *
+ *  @param  recoOption the reco option string
+ *  @param  parameters to receive the application parameters
+ *
+ *  @return success
+ */
+bool ProcessRecoOption(const std::string &recoOption, Parameters &parameters);
+
+/**
+ *  @brief  Process list of external, commandline parameters to be passed to specific algorithms
+ *
+ *  @param  parameters the parameters
+ *  @param  pPandora the address of the pandora instance
+ */
+void ProcessExternalParameters(const Parameters &parameters, const pandora::Pandora *const pPandora);
 
 } // namespace lar_nd_reco
 

--- a/settings/PandoraSettings_EDepReco.xml
+++ b/settings/PandoraSettings_EDepReco.xml
@@ -41,14 +41,6 @@
         <RecreatedClusterListName>RecreatedClusters</RecreatedClusterListName>
         <RecreatedVertexListName>RecreatedVertices</RecreatedVertexListName>
         <VisualizeOverallRecoStatus>false</VisualizeOverallRecoStatus>
-
-        <ShouldRunAllHitsCosmicReco>true</ShouldRunAllHitsCosmicReco>
-        <ShouldRunStitching>true</ShouldRunStitching>
-        <ShouldRunCosmicHitRemoval>false</ShouldRunCosmicHitRemoval>
-        <ShouldRunSlicing>false</ShouldRunSlicing>
-        <ShouldRunNeutrinoRecoOption>true</ShouldRunNeutrinoRecoOption>
-        <ShouldRunCosmicRecoOption>false</ShouldRunCosmicRecoOption>
-        <ShouldPerformSliceId>false</ShouldPerformSliceId>
     </algorithm>
 
     <algorithm type = "LArMCParticleMonitoring">

--- a/settings/PandoraSettings_EDepReco.xml
+++ b/settings/PandoraSettings_EDepReco.xml
@@ -23,7 +23,7 @@
 
     <algorithm type = "LArMaster">
         <CRSettingsFile>PandoraSettings_Cosmic_Standard.xml</CRSettingsFile>
-        <NuSettingsFile>PandoraSettings_Neutrino_MicroBooNE.xml</NuSettingsFile>
+        <NuSettingsFile>PandoraSettings_Neutrino_Standard.xml</NuSettingsFile>
         <SlicingSettingsFile>PandoraSettings_Slicing_Standard.xml</SlicingSettingsFile>
         <StitchingTools>
             <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>true</ThreeDStitchingMode></tool>
@@ -33,10 +33,7 @@
             <tool type = "LArCosmicRayTagging"/>
         </CosmicRayTaggingTools>
         <SliceIdTools>
-            <tool type = "LArSvmNeutrinoId">
-                <MvaFileName>PandoraSvm_v03_11_00.xml</MvaFileName>
-                <MvaName>NeutrinoId</MvaName>
-            </tool>
+            <tool type = "LArSimpleNeutrinoId"/>
         </SliceIdTools>
         <InputHitListName>CaloHitList2D</InputHitListName>
         <RecreatedPfoListName>RecreatedPfos</RecreatedPfoListName>

--- a/settings/PandoraSettings_EDepReco.xml
+++ b/settings/PandoraSettings_EDepReco.xml
@@ -53,12 +53,18 @@
         <ShouldPerformSliceId>false</ShouldPerformSliceId>
     </algorithm>
 
+    <algorithm type = "LArMCParticleMonitoring">
+        <CaloHitListName>CaloHitList2D</CaloHitListName>
+        <MCParticleListName>Input</MCParticleListName>
+        <MinHitsForDisplay>0</MinHitsForDisplay>
+    </algorithm>
+
     <algorithm type = "LArNeutrinoEventValidation">
         <CaloHitListName>CaloHitList2D</CaloHitListName>
         <MCParticleListName>Input</MCParticleListName>
         <PfoListName>RecreatedPfos</PfoListName>
-        <UseTrueNeutrinosOnly>false</UseTrueNeutrinosOnly>
-        <PrintAllToScreen>false</PrintAllToScreen>
+        <UseTrueNeutrinosOnly>true</UseTrueNeutrinosOnly>
+        <PrintAllToScreen>true</PrintAllToScreen>
         <PrintMatchingToScreen>true</PrintMatchingToScreen>
         <WriteToTree>false</WriteToTree>
         <OutputTree>Validation</OutputTree>

--- a/settings/PandoraSettings_EDepReco.xml
+++ b/settings/PandoraSettings_EDepReco.xml
@@ -23,7 +23,8 @@
 
     <algorithm type = "LArMaster">
         <CRSettingsFile>PandoraSettings_Cosmic_Standard.xml</CRSettingsFile>
-        <NuSettingsFile>PandoraSettings_Neutrino_Standard.xml</NuSettingsFile>
+        <!--Use MicroBooNE neutrino algorithms for now-->
+        <NuSettingsFile>PandoraSettings_Neutrino_MicroBooNE.xml</NuSettingsFile>
         <SlicingSettingsFile>PandoraSettings_Slicing_Standard.xml</SlicingSettingsFile>
         <StitchingTools>
             <tool type = "LArStitchingCosmicRayMerging"><ThreeDStitchingMode>true</ThreeDStitchingMode></tool>
@@ -45,7 +46,7 @@
         <ShouldRunStitching>true</ShouldRunStitching>
         <ShouldRunCosmicHitRemoval>false</ShouldRunCosmicHitRemoval>
         <ShouldRunSlicing>false</ShouldRunSlicing>
-        <ShouldRunNeutrinoRecoOption>false</ShouldRunNeutrinoRecoOption>
+        <ShouldRunNeutrinoRecoOption>true</ShouldRunNeutrinoRecoOption>
         <ShouldRunCosmicRecoOption>false</ShouldRunCosmicRecoOption>
         <ShouldPerformSliceId>false</ShouldPerformSliceId>
     </algorithm>
@@ -63,7 +64,7 @@
         <UseTrueNeutrinosOnly>true</UseTrueNeutrinosOnly>
         <PrintAllToScreen>true</PrintAllToScreen>
         <PrintMatchingToScreen>true</PrintMatchingToScreen>
-        <WriteToTree>false</WriteToTree>
+        <WriteToTree>true</WriteToTree>
         <OutputTree>Validation</OutputTree>
         <OutputFile>Validation.root</OutputFile>
     </algorithm>

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -513,7 +513,7 @@ MCParticleEnergyMap CreateMCParticles(const TG4Event &event, const pandora::Pand
         PANDORA_THROW_RESULT_IF(
             pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::MCParticle::Create(*pPrimaryPandora, mcParticleParameters, mcParticleFactory));
 
-        // Set parent relationships - TODO, check inclusion of mc neutrino here
+        // Set parent relationships
         const int parentID = g4Traj.GetParentId();
 
         if (parentID < 0) // link to mc neutrino
@@ -557,16 +557,16 @@ int GetNuanceCode(const std::string &reaction)
     // https://github.com/GENIE-MC/Generator/blob/master/src/contrib/t2k/neut_code_from_rootracker.C#L276
     int code(1000);
 
-    bool is_cc = (reaction.find("Weak[CC]") != std::string::npos); // weak charged-current
-    bool is_nc = (reaction.find("Weak[NC]") != std::string::npos); // weak neutral-current
-    //bool is_charm = (reaction.find("charm")    != std::string::npos); // charm production
-    bool is_qel = (reaction.find("QES") != std::string::npos);   // quasi-elastic scattering
-    bool is_dis = (reaction.find("DIS") != std::string::npos);   // deep inelastic scattering
-    bool is_res = (reaction.find("RES") != std::string::npos);   // resonance
-    bool is_cohpi = (reaction.find("COH") != std::string::npos); // coherent pi
-    bool is_ve = (reaction.find("NuEEL") != std::string::npos);  // nu e elastic
-    bool is_imd = (reaction.find("IMD") != std::string::npos);   // inverse mu decay
-    bool is_mec = (reaction.find("MEC") != std::string::npos);   // meson exchange current
+    const bool is_cc = (reaction.find("Weak[CC]") != std::string::npos); // weak charged-current
+    const bool is_nc = (reaction.find("Weak[NC]") != std::string::npos); // weak neutral-current
+    // const bool is_charm = (reaction.find("charm")    != std::string::npos); // charm production
+    const bool is_qel = (reaction.find("QES") != std::string::npos);   // quasi-elastic scattering
+    const bool is_dis = (reaction.find("DIS") != std::string::npos);   // deep inelastic scattering
+    const bool is_res = (reaction.find("RES") != std::string::npos);   // resonance
+    const bool is_cohpi = (reaction.find("COH") != std::string::npos); // coherent pi
+    const bool is_ve = (reaction.find("NuEEL") != std::string::npos);  // nu e elastic
+    const bool is_imd = (reaction.find("IMD") != std::string::npos);   // inverse mu decay
+    const bool is_mec = (reaction.find("MEC") != std::string::npos);   // meson exchange current
 
     if (is_qel)
     {

--- a/test/PandoraInterface.cxx
+++ b/test/PandoraInterface.cxx
@@ -448,9 +448,6 @@ MCParticleEnergyMap CreateMCParticles(const TG4Event &event, const pandora::Pand
         const int trackID = g4Traj.GetTrackId();
         mcParticleParameters.m_pParentAddress = (void *)((intptr_t)trackID);
 
-        // Link to MC Neutrino
-        PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::SetMCParentDaughterRelationship(*pPrimaryPandora, (void*)((intptr_t)neutrinoID), (void*)((intptr_t)trackID)));
-
         // Start and end points in cm (Geant4 uses mm)
         const std::vector<TG4TrajectoryPoint> trajPoints = g4Traj.Points;
         const int nPoints(trajPoints.size());
@@ -479,9 +476,18 @@ MCParticleEnergyMap CreateMCParticles(const TG4Event &event, const pandora::Pand
         PANDORA_THROW_RESULT_IF(
             pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::MCParticle::Create(*pPrimaryPandora, mcParticleParameters, mcParticleFactory));
 
-        // Set parent relationship
+        // Set parent relationships - TODO, check inclusion of mc neutrino here
         const int parentID = g4Traj.GetParentId();
-        PandoraApi::SetMCParentDaughterRelationship(*pPrimaryPandora, (void *)((intptr_t)parentID), (void *)((intptr_t)trackID));
+
+        if (parentID < 0) // link to mc neutrino
+        {
+            PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::SetMCParentDaughterRelationship(*pPrimaryPandora, (void*)((intptr_t)neutrinoID), (void*)((intptr_t)trackID)));
+
+        }
+        else
+        {
+            PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::SetMCParentDaughterRelationship(*pPrimaryPandora, (void *)((intptr_t)parentID), (void *)((intptr_t)trackID)));
+        }
 
         // Store particle energy for given trackID
         energyMap[trackID] = energy;


### PR DESCRIPTION
These code changes allow for the reconstruction and MC association of PFOs from neutrino events generated with GENIE and edep-sim for the ND work (assuming the ArgonCube geometry). For now, we are using the MicroBooNE-tuned neutrino algorithms.
