### PR TITLE
Generalise CreateGeometry() and ProcessEvents() in PandoraInterface for any detector name.

### DIFF
--- a/include/PandoraInterface.h
+++ b/include/PandoraInterface.h
@@ -39,6 +39,9 @@ public:
     std::string m_inputFileName; ///< The path to the input file containing events
                                  ///< and/or geometry information
 
+    std::string m_geometryVolName;  ///< The name of the Geant4 detector placement volume
+    std::string m_sensitiveDetName; ///< The name of the Geant4 sensitive hit detector
+
     int m_nEventsToProcess;          ///< The number of events to process (default all
                                      ///< events in file)
     bool m_shouldDisplayEventNumber; ///< Whether event numbers should be


### PR DESCRIPTION
These changes allow us to run the `feature/edep-reco` code for any Geant4 volume placement and sensitive detector names used in the `edep-sim` simulation output, instead of just `ArgonCube`. However, we still assume that the volume is a cube in order to get the geometry parameters and boundaries.

The `-g` run option specifies the name of the Geant4 placement volume that is used in `CreateGeometry()`to find the geometry parameters and boundaries. The default name is `volArgonCubeDetector`.

The `-d` run option specifies the name of the Geant4 sensitive detector that contains the hits in `ProcessEvents()`. The default name is `ArgonCube`.