### PR TITLE
Remove redundant track/shower characterisation

### DIFF
--- a/settings/PandoraSettings_Neutrino_DUNEFD.xml
+++ b/settings/PandoraSettings_Neutrino_DUNEFD.xml
@@ -106,18 +106,6 @@
     </algorithm>
     <algorithm type = "LArHitWidthClusterMerging"/>
 
-    <!-- VertexAlgorithms -->
-    <algorithm type = "LArCutClusterCharacterisation">
-        <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
-        <MaxShowerLengthCut>500.</MaxShowerLengthCut>
-        <VertexDistanceRatioCut>500.</VertexDistanceRatioCut>
-        <PathLengthRatioCut>1.012</PathLengthRatioCut>
-        <ShowerWidthRatioCut>0.2</ShowerWidthRatioCut>
-    </algorithm>
-    <algorithm type = "LArCutClusterCharacterisation">
-        <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
-        <ZeroMode>true</ZeroMode>
-    </algorithm>
     <algorithm type = "LArVertexSplitting">
         <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
     </algorithm>


### PR DESCRIPTION
Addresses Issue #76 .

Only present in this single xml. In other xmls, it has either already been removed or the old vertex algorithms are still in use.