### PR TITLE
Update FD xmls for DL shower growing

### DIFF
--- a/settings/PandoraSettings_Neutrino_Atmos_DUNEFD.xml
+++ b/settings/PandoraSettings_Neutrino_Atmos_DUNEFD.xml
@@ -109,6 +109,21 @@
         <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
     </algorithm>
 
+    <algorithm type = "LArDLTwoDShowerGrowing">
+        <ClusterListNames>ClustersU ClustersV ClustersW</ClusterListNames>
+        <VertexListName>NeutrinoVertices3D</VertexListName>
+        <ModelEncoderFileName>PandoraNetworkData/PandoraNet_ShowerGrowing_DUNEFD_HD_Encoder_v05_00_00.pt</ModelEncoderFileName>
+        <ModelAttnFileName>PandoraNetworkData/PandoraNet_ShowerGrowing_DUNEFD_HD_Attn_v05_00_00.pt</ModelAttnFileName>
+        <ModelSimFileName>PandoraNetworkData/PandoraNet_ShowerGrowing_DUNEFD_HD_Sim_v05_00_00.pt</ModelSimFileName>
+        <SimilarityThreshold>0.60</SimilarityThreshold>
+        <SimilarityThresholdBeta>1.0</SimilarityThresholdBeta>
+        <AccessoryClusterMaxHits>2</AccessoryClusterMaxHits>
+        <MaxIterations>10</MaxIterations>
+        <PolarRScaleFactor>0.0005044863</PolarRScaleFactor>
+        <CartesianXScaleFactor>0.001378694</CartesianXScaleFactor>
+        <CartesianZScaleFactor>0.0007171852</CartesianZScaleFactor>
+    </algorithm>
+
     <!-- ThreeDTrackAlgorithms -->
     <algorithm type = "LArThreeDTransverseTracks">
         <InputClusterListNameU>ClustersU</InputClusterListNameU>
@@ -139,17 +154,6 @@
             <tool type = "LArMatchedEndPoints"/>
         </TrackTools>
     </algorithm>
-    <algorithm type = "LArThreeDTrackFragments">
-        <MinClusterLength>5.</MinClusterLength>
-        <InputClusterListNameU>ClustersU</InputClusterListNameU>
-        <InputClusterListNameV>ClustersV</InputClusterListNameV>
-        <InputClusterListNameW>ClustersW</InputClusterListNameW>
-        <OutputPfoListName>TrackParticles3D</OutputPfoListName>
-        <TrackTools>
-            <tool type = "LArClearTrackFragments"/>
-        </TrackTools>
-        <algorithm type = "LArSimpleClusterCreation" description = "ClusterRebuilding"/>
-    </algorithm>
 
     <!-- ThreeDShowerAlgorithms -->
     <algorithm type = "LArCutPfoCharacterisation">
@@ -169,9 +173,6 @@
         <VertexDistanceRatioCut>500.</VertexDistanceRatioCut>
         <PathLengthRatioCut>1.012</PathLengthRatioCut>
         <ShowerWidthRatioCut>0.2</ShowerWidthRatioCut>
-    </algorithm>
-    <algorithm type = "LArShowerGrowing">
-        <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
     </algorithm>
     <algorithm type = "LArThreeDShowers">
         <InputClusterListNameU>ClustersU</InputClusterListNameU>

--- a/settings/PandoraSettings_Neutrino_DUNEFD.xml
+++ b/settings/PandoraSettings_Neutrino_DUNEFD.xml
@@ -110,6 +110,21 @@
         <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
     </algorithm>
 
+    <algorithm type = "LArDLTwoDShowerGrowing">
+        <ClusterListNames>ClustersU ClustersV ClustersW</ClusterListNames>
+        <VertexListName>NeutrinoVertices3D</VertexListName>
+        <ModelEncoderFileName>PandoraNetworkData/PandoraNet_ShowerGrowing_DUNEFD_HD_Encoder_v05_00_00.pt</ModelEncoderFileName>
+        <ModelAttnFileName>PandoraNetworkData/PandoraNet_ShowerGrowing_DUNEFD_HD_Attn_v05_00_00.pt</ModelAttnFileName>
+        <ModelSimFileName>PandoraNetworkData/PandoraNet_ShowerGrowing_DUNEFD_HD_Sim_v05_00_00.pt</ModelSimFileName>
+        <SimilarityThreshold>0.60</SimilarityThreshold>
+        <SimilarityThresholdBeta>1.0</SimilarityThresholdBeta>
+        <AccessoryClusterMaxHits>2</AccessoryClusterMaxHits>
+        <MaxIterations>10</MaxIterations>
+        <PolarRScaleFactor>0.0005044863</PolarRScaleFactor>
+        <CartesianXScaleFactor>0.001378694</CartesianXScaleFactor>
+        <CartesianZScaleFactor>0.0007171852</CartesianZScaleFactor>
+    </algorithm>
+
     <!-- ThreeDTrackAlgorithms -->
     <algorithm type = "LArThreeDTransverseTracks">
         <InputClusterListNameU>ClustersU</InputClusterListNameU>
@@ -140,17 +155,6 @@
             <tool type = "LArMatchedEndPoints"/>
         </TrackTools>
     </algorithm>
-    <algorithm type = "LArThreeDTrackFragments">
-        <MinClusterLength>5.</MinClusterLength>
-        <InputClusterListNameU>ClustersU</InputClusterListNameU>
-        <InputClusterListNameV>ClustersV</InputClusterListNameV>
-        <InputClusterListNameW>ClustersW</InputClusterListNameW>
-        <OutputPfoListName>TrackParticles3D</OutputPfoListName>
-        <TrackTools>
-            <tool type = "LArClearTrackFragments"/>
-        </TrackTools>
-        <algorithm type = "LArSimpleClusterCreation" description = "ClusterRebuilding"/>
-    </algorithm>
 
     <!-- ThreeDShowerAlgorithms -->
     <algorithm type = "LArCutPfoCharacterisation">
@@ -170,9 +174,6 @@
         <VertexDistanceRatioCut>500.</VertexDistanceRatioCut>
         <PathLengthRatioCut>1.012</PathLengthRatioCut>
         <ShowerWidthRatioCut>0.2</ShowerWidthRatioCut>
-    </algorithm>
-    <algorithm type = "LArShowerGrowing">
-        <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
     </algorithm>
     <algorithm type = "LArThreeDShowers">
         <InputClusterListNameU>ClustersU</InputClusterListNameU>

--- a/settings/PandoraSettings_Neutrino_DUNEFD_VD.xml
+++ b/settings/PandoraSettings_Neutrino_DUNEFD_VD.xml
@@ -138,6 +138,21 @@
         <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
     </algorithm>
 
+    <algorithm type = "LArDLTwoDShowerGrowing">
+        <ClusterListNames>ClustersU ClustersV ClustersW</ClusterListNames>
+        <VertexListName>NeutrinoVertices3D</VertexListName>
+        <ModelEncoderFileName>PandoraNetworkData/PandoraNet_ShowerGrowing_DUNEFD_VD_Encoder_v05_00_00.pt</ModelEncoderFileName>
+        <ModelAttnFileName>PandoraNetworkData/PandoraNet_ShowerGrowing_DUNEFD_VD_Attn_v05_00_00.pt</ModelAttnFileName>
+        <ModelSimFileName>PandoraNetworkData/PandoraNet_ShowerGrowing_DUNEFD_VD_Sim_v05_00_00.pt</ModelSimFileName>
+        <SimilarityThreshold>0.60</SimilarityThreshold>
+        <SimilarityThresholdBeta>1.0</SimilarityThresholdBeta>
+        <AccessoryClusterMaxHits>2</AccessoryClusterMaxHits>
+        <MaxIterations>10</MaxIterations>
+        <PolarRScaleFactor>0.0005742559</PolarRScaleFactor>
+        <CartesianXScaleFactor>0.001538462</CartesianXScaleFactor>
+        <CartesianZScaleFactor>0.00111667</CartesianZScaleFactor>
+    </algorithm>
+
     <!-- ThreeDTrackAlgorithms -->
     <algorithm type = "LArThreeDTransverseTracks">
         <InputClusterListNameU>ClustersU</InputClusterListNameU>
@@ -168,17 +183,6 @@
             <tool type = "LArMatchedEndPoints"/>
         </TrackTools>
     </algorithm>
-    <algorithm type = "LArThreeDTrackFragments">
-        <MinClusterLength>5.</MinClusterLength>
-        <InputClusterListNameU>ClustersU</InputClusterListNameU>
-        <InputClusterListNameV>ClustersV</InputClusterListNameV>
-        <InputClusterListNameW>ClustersW</InputClusterListNameW>
-        <OutputPfoListName>TrackParticles3D</OutputPfoListName>
-        <TrackTools>
-            <tool type = "LArClearTrackFragments"/>
-        </TrackTools>
-        <algorithm type = "LArSimpleClusterCreation" description = "ClusterRebuilding"/>
-    </algorithm>
 
     <!-- ThreeDShowerAlgorithms -->
     <algorithm type = "LArCutPfoCharacterisation">
@@ -198,9 +202,6 @@
         <VertexDistanceRatioCut>500.</VertexDistanceRatioCut>
         <PathLengthRatioCut>1.012</PathLengthRatioCut>
         <ShowerWidthRatioCut>0.2</ShowerWidthRatioCut>
-    </algorithm>
-    <algorithm type = "LArShowerGrowing">
-        <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
     </algorithm>
     <algorithm type = "LArThreeDShowers">
         <InputClusterListNameU>ClustersU</InputClusterListNameU>


### PR DESCRIPTION
Updates FD neutrino xmls to the new shower growing workflows.

Now that the old shower growing is gone, maybe the "Repeat ThreeDTrackAlgorithms" block is not needed, I am testing this.